### PR TITLE
Add functionality to copy subdirectories

### DIFF
--- a/copyscript
+++ b/copyscript
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-DIR=`pwd`
-DIRECTORY=$1
+# Trim trailing slashes from input (necessary for grep)
+DIRECTORY=$(echo $1 | sed 's:/*$::')
 
 if [ -d "$DIRECTORY" ]; then
-  cp -v $DIR/* $DIRECTORY | cat -n
+  cp -vR `ls -A | grep -v "^$DIRECTORY\$"` $DIRECTORY | cat -n
   echo "Files copied succesfully"
 elif [[ -f $DIRECTORY ]]; then
   echo "$DIRECTORY is a file"


### PR DESCRIPTION
Adds functionality to copy subdirectories recursively.

Before:

```sh
$ mkdir a b
$ ls -p
LICENSE     README.md   a/          b/          copyscript
$ ./copyscript a/
cp: /path/to/pwd/a is a directory (not copied).
cp: /path/to/pwd/b is a directory (not copied).
     1  /path/to/pwd/LICENSE -> a/LICENSE
     2  /path/to/pwd/README.md -> a/README.md
     3  /path/to/pwd/copyscript -> a/copyscript
Files copied succesfully
```

Now:

```sh
$ mkdir a b
$ ls -p
LICENSE     README.md   a/          b/          copyscript
$ ./copyscript a/
     1  LICENSE -> a/LICENSE
     2  README.md -> a/README.md
     3  b -> a/b
     4  copyscript -> a/copyscript
Files copied succesfully
```

So what's happening here is that instead of using `$PWD/*` to find files in the working directory, it's using `ls -A` and then grepping out `$DIRECTORY` (i.e. the destination). The _downside_ of doing it this way is that we're no longer seeing absolute paths in the `cat` output, since `ls` doesn't give us absolute paths (let me know if this is a problem).